### PR TITLE
Add implementation for images.

### DIFF
--- a/include/MLX42/MLX42.h
+++ b/include/MLX42/MLX42.h
@@ -6,7 +6,7 @@
 /*   By: W2Wizard <w2.wizzard@gmail.com>              +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2021/12/28 00:33:01 by W2Wizard      #+#    #+#                 */
-/*   Updated: 2022/01/19 18:00:01 by lde-la-h      ########   odam.nl         */
+/*   Updated: 2022/01/21 18:12:49 by W2Wizard      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -53,22 +53,40 @@ typedef struct s_xpm
 }	t_xpm;
 
 /**
- * Main MLX handle, carries important data in regards to the program.
- * @param window The window itself.
- * @param hooks List of all the current hooks.
+ * An image with an individual buffer that can be rendered.
+ * 
  * @param width The width.
  * @param height The height.
  * @param pixels The literal pixel data.
+ * @param context Abstracted data.
+ */
+typedef struct s_mlx_image
+{
+	int32_t	width;
+	int32_t	height;
+	uint8_t	*pixels;
+	void	*context;
+}	t_mlx_image;
+
+/**
+ * Main MLX handle, carries important data in regards to the program.
+ * @param window The window itself.
+ * @param hooks List of all the current hooks.
+ * @param images List of all the current images.
  * @param context Abstracted opengl data.
+ * @param width The width.
+ * @param height The height.
+ * @param pixels The literal pixel data.
  */
 typedef struct s_mlx
 {
 	void		*window;
 	void		*hooks;
+	void		*images;
+	void		*context;
 	int32_t		width;
 	int32_t		height;
 	uint8_t		*pixels;
-	void		*context;
 	double		delta_time;
 }	t_mlx;
 
@@ -276,6 +294,17 @@ void	mlx_set_cursor(t_mlx *mlx, void *cursor);
  * @returns The XPM image struct containing its information.
  */
 t_xpm	*mlx_load_xpm42(const char *path);
+
+/**
+ * Creates and allocates a new image buffer.
+ * 
+ * @param[in] width The desired width of the image.
+ * @param[in] height The desired height of the image.
+ * @return Pointer to the image buffer, if it failed to allocate then NULL.
+ */
+t_mlx_image	*mlx_new_image(uint16_t width, uint16_t height);
+
+void	mlx_draw_image(t_mlx *mlx, t_mlx_image *img, uint16_t x, uint16_t y);
 
 //void	mlx_draw_xpm(t_mlx *mlx, t_xpm *xpm, int32_t X, int32_t Y);
 

--- a/include/MLX42/MLX42.h
+++ b/include/MLX42/MLX42.h
@@ -6,7 +6,7 @@
 /*   By: W2Wizard <w2.wizzard@gmail.com>              +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2021/12/28 00:33:01 by W2Wizard      #+#    #+#                 */
-/*   Updated: 2022/01/22 14:53:15 by W2Wizard      ########   odam.nl         */
+/*   Updated: 2022/01/22 16:27:45 by W2Wizard      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -54,19 +54,24 @@ typedef struct s_xpm
 
 /**
  * An image with an individual buffer that can be rendered.
+ * Any value can be modified except the width/height and context.
  * 
- * @param width The width.
- * @param height The height.
+ * @param x The x location of the image.
+ * @param y The y location of the image.
+ * @param depth The depth controls in Z layer it is drawn in.
  * @param pixels The literal pixel data.
+ * @param width The width of the image.
+ * @param height The height of the image.
  * @param context Abstracted data.
  */
 typedef struct s_mlx_image
 {
 	int32_t	x;
 	int32_t	y;
-	int32_t	width;
-	int32_t	height;
+	int32_t	depth;
 	uint8_t	*pixels;
+	int32_t	height;
+	int32_t	width;
 	void	*context;
 }	t_mlx_image;
 
@@ -78,7 +83,6 @@ typedef struct s_mlx_image
  * @param context Abstracted opengl data.
  * @param width The width.
  * @param height The height.
- * @param pixels The literal pixel data.
  */
 typedef struct s_mlx
 {
@@ -88,7 +92,6 @@ typedef struct s_mlx
 	void		*context;
 	int32_t		width;
 	int32_t		height;
-	uint8_t		*pixels;
 	double		delta_time;
 }	t_mlx;
 
@@ -192,18 +195,6 @@ void	mlx_set_window_pos(t_mlx *mlx, int32_t xpos, int32_t ypos);
  */
 void	mlx_get_window_pos(t_mlx *mlx, int32_t *xpos, int32_t *ypos);
 
-//= Pixel Functions =//
-
-/**
- * Sets / puts a pixel onto the screen using 
- * 
- * @param[in] MLX The MLX instance handle.
- * @param[in] X The X coordinate position.
- * @param[in] Y The Y coordinate position.
- * @param[in] Color The RGBA8 Color value.
- */
-void	mlx_putpixel(t_mlx *MLX, int32_t X, int32_t Y, int32_t Color);
-
 //= Input Functions =//
 
 /**
@@ -300,6 +291,16 @@ t_xpm	*mlx_load_xpm42(const char *path);
 //= Image Functions =//
 
 /**
+ * Sets / puts a pixel onto an image.
+ * 
+ * @param[in] img The MLX instance handle.
+ * @param[in] X The X coordinate position.
+ * @param[in] Y The Y coordinate position.
+ * @param[in] Color The RGBA8 Color value.
+ */
+void	mlx_putpixel(t_mlx_image *img, int32_t X, int32_t Y, int32_t Color);
+
+/**
  * Creates and allocates a new image buffer.
  * 
  * @param[in] mlx The MLX instance handle.
@@ -318,7 +319,7 @@ t_mlx_image	*mlx_new_image(t_mlx *mlx, uint16_t width, uint16_t height);
  * @param[in] x The X position.
  * @param[in] y The Y poistion.
  */
-void	mlx_draw_image(t_mlx *mlx, t_mlx_image *img, uint16_t x, uint16_t y);
+void	mlx_draw_image(t_mlx *mlx, t_mlx_image *img, int32_t x, int32_t y);
 
 //void	mlx_draw_xpm(t_mlx *mlx, t_xpm *xpm, int32_t X, int32_t Y);
 

--- a/include/MLX42/MLX42.h
+++ b/include/MLX42/MLX42.h
@@ -6,7 +6,7 @@
 /*   By: W2Wizard <w2.wizzard@gmail.com>              +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2021/12/28 00:33:01 by W2Wizard      #+#    #+#                 */
-/*   Updated: 2022/01/21 18:12:49 by W2Wizard      ########   odam.nl         */
+/*   Updated: 2022/01/21 18:28:51 by W2Wizard      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -298,11 +298,12 @@ t_xpm	*mlx_load_xpm42(const char *path);
 /**
  * Creates and allocates a new image buffer.
  * 
+ * @param[in] mlx The MLX instance handle.
  * @param[in] width The desired width of the image.
  * @param[in] height The desired height of the image.
  * @return Pointer to the image buffer, if it failed to allocate then NULL.
  */
-t_mlx_image	*mlx_new_image(uint16_t width, uint16_t height);
+t_mlx_image	*mlx_new_image(t_mlx *mlx, uint16_t width, uint16_t height);
 
 void	mlx_draw_image(t_mlx *mlx, t_mlx_image *img, uint16_t x, uint16_t y);
 

--- a/include/MLX42/MLX42.h
+++ b/include/MLX42/MLX42.h
@@ -6,7 +6,7 @@
 /*   By: W2Wizard <w2.wizzard@gmail.com>              +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2021/12/28 00:33:01 by W2Wizard      #+#    #+#                 */
-/*   Updated: 2022/01/21 20:22:22 by W2Wizard      ########   odam.nl         */
+/*   Updated: 2022/01/22 14:28:34 by W2Wizard      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -62,6 +62,8 @@ typedef struct s_xpm
  */
 typedef struct s_mlx_image
 {
+	int32_t	x;
+	int32_t	y;
 	int32_t	width;
 	int32_t	height;
 	uint8_t	*pixels;
@@ -295,6 +297,8 @@ void	mlx_set_cursor(t_mlx *mlx, void *cursor);
  */
 t_xpm	*mlx_load_xpm42(const char *path);
 
+//= Image Functions =//
+
 /**
  * Creates and allocates a new image buffer.
  * 
@@ -305,7 +309,15 @@ t_xpm	*mlx_load_xpm42(const char *path);
  */
 t_mlx_image	*mlx_new_image(t_mlx *mlx, uint16_t width, uint16_t height);
 
-void	mlx_draw_image(t_mlx *mlx, t_mlx_image *img, uint16_t x, uint16_t y, int32_t ZOffset);
+/**
+ * Draws the image onto the specified screen coordinates.
+ * 
+ * @param[in] mlx The MLX instance handle.
+ * @param[in] img The image to draw onto the screen.
+ * @param[in] x The X position.
+ * @param[in] y The Y poistion.
+ */
+void	mlx_draw_image(t_mlx *mlx, t_mlx_image *img, uint16_t x, uint16_t y);
 
 //void	mlx_draw_xpm(t_mlx *mlx, t_xpm *xpm, int32_t X, int32_t Y);
 

--- a/include/MLX42/MLX42.h
+++ b/include/MLX42/MLX42.h
@@ -6,7 +6,7 @@
 /*   By: W2Wizard <w2.wizzard@gmail.com>              +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2021/12/28 00:33:01 by W2Wizard      #+#    #+#                 */
-/*   Updated: 2022/01/21 18:28:51 by W2Wizard      ########   odam.nl         */
+/*   Updated: 2022/01/21 20:22:22 by W2Wizard      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -305,7 +305,7 @@ t_xpm	*mlx_load_xpm42(const char *path);
  */
 t_mlx_image	*mlx_new_image(t_mlx *mlx, uint16_t width, uint16_t height);
 
-void	mlx_draw_image(t_mlx *mlx, t_mlx_image *img, uint16_t x, uint16_t y);
+void	mlx_draw_image(t_mlx *mlx, t_mlx_image *img, uint16_t x, uint16_t y, int32_t ZOffset);
 
 //void	mlx_draw_xpm(t_mlx *mlx, t_xpm *xpm, int32_t X, int32_t Y);
 

--- a/include/MLX42/MLX42.h
+++ b/include/MLX42/MLX42.h
@@ -6,7 +6,7 @@
 /*   By: W2Wizard <w2.wizzard@gmail.com>              +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2021/12/28 00:33:01 by W2Wizard      #+#    #+#                 */
-/*   Updated: 2022/01/22 14:28:34 by W2Wizard      ########   odam.nl         */
+/*   Updated: 2022/01/22 14:53:15 by W2Wizard      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -311,6 +311,7 @@ t_mlx_image	*mlx_new_image(t_mlx *mlx, uint16_t width, uint16_t height);
 
 /**
  * Draws the image onto the specified screen coordinates.
+ * NOTE: You can modify the images x & y coordinate directly to move it.
  * 
  * @param[in] mlx The MLX instance handle.
  * @param[in] img The image to draw onto the screen.

--- a/include/MLX42/MLX42_Int.h
+++ b/include/MLX42/MLX42_Int.h
@@ -6,7 +6,7 @@
 /*   By: W2Wizard <w2.wizzard@gmail.com>              +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2021/12/27 23:55:34 by W2Wizard      #+#    #+#                 */
-/*   Updated: 2022/01/21 16:53:01 by W2Wizard      ########   odam.nl         */
+/*   Updated: 2022/01/21 19:29:48 by W2Wizard      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -67,7 +67,7 @@ typedef struct s_mlx_ctx
 // Context for image.
 typedef struct s_mlx_image_ctx
 {
-	t_vert	vertices[8];
+	t_vert	vertices[6];
 	GLuint	texture;
 }	t_mlx_image_ctx;
 

--- a/include/MLX42/MLX42_Int.h
+++ b/include/MLX42/MLX42_Int.h
@@ -6,7 +6,7 @@
 /*   By: W2Wizard <w2.wizzard@gmail.com>              +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2021/12/27 23:55:34 by W2Wizard      #+#    #+#                 */
-/*   Updated: 2022/01/19 00:30:01 by W2Wizard      ########   odam.nl         */
+/*   Updated: 2022/01/21 16:53:01 by W2Wizard      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -45,17 +45,34 @@
 
 //= Types =//
 
+// A single vertex.
+typedef struct s_vert
+{
+	float	x;
+	float	y;
+	float	z;
+	float	u;
+	float	v;
+}	t_vert;
+
 // OpenGL variables.
 typedef struct s_mlx_ctx
 {
-	uint32_t	shaderprogram;
-	uint32_t	texture;
-	uint32_t	vao;
-	uint32_t	vbo;
-	uint32_t	ebo;
+	GLuint	vao;
+	GLuint	vbo;
+	GLuint	ebo;
+	GLuint	shaderprogram;
 }	t_mlx_ctx;
 
-// Struct witholding a simple hook function with a param.
+// Context for image.
+typedef struct s_mlx_image_ctx
+{
+	t_vert	vertices[8];
+	GLuint	texture;
+}	t_mlx_image_ctx;
+
+// Struct witholding a hook function with a param.
+// TODO: Rename to functor;
 typedef struct s_mlx_hook
 {
 	void	*param;
@@ -86,6 +103,7 @@ void		mlx_lstadd_back(t_mlx_list **lst, t_mlx_list *new);
 bool		mlx_error(const char *error);
 bool		mlx_free_va(bool output, int32_t count, ...);
 
+void		mlx_set_image_shader(t_mlx *mlx);
 bool		mlx_compile_shader(const char *Path, int32_t Type, uint32_t *out);
 bool		mlx_init_shaders(t_mlx *mlx, uint32_t *shaders);
 char		*mlx_readfile(const char *FilePath);

--- a/include/MLX42/MLX42_Int.h
+++ b/include/MLX42/MLX42_Int.h
@@ -6,7 +6,7 @@
 /*   By: W2Wizard <w2.wizzard@gmail.com>              +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2021/12/27 23:55:34 by W2Wizard      #+#    #+#                 */
-/*   Updated: 2022/01/21 19:29:48 by W2Wizard      ########   odam.nl         */
+/*   Updated: 2022/01/22 13:59:43 by W2Wizard      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,9 +17,6 @@
 # include "KHR/khrplatform.h"
 # if defined(__APPLE__)
 #  define GL_SILENCE_DEPRECATION
-#  define IS_APPLE 1
-# else
-#  define IS_APPLE 0
 # endif
 # include <GLFW/glfw3.h>
 # include <stdlib.h>
@@ -27,6 +24,7 @@
 # include <stdio.h>
 # include <limits.h>
 # include <ctype.h>
+# include <string.h>
 # ifndef VERTEX_PATH
 #  define VERTEX_PATH "shaders/default.vert"
 # endif

--- a/shaders/default.vert
+++ b/shaders/default.vert
@@ -1,14 +1,12 @@
 #version 330 core
 layout (location = 0) in vec3 aPos;
-layout (location = 1) in vec3 aColor;
-layout (location = 2) in vec2 aTexCoord;
+layout (location = 1) in vec2 aTexCoord;
 
-out vec3 ourColor;
 out vec2 TexCoord;
+uniform mat4 proj_matrix;
 
 void main()
 {
-    ourColor = aColor;
+	gl_Position = proj_matrix * vec4(aPos, 1.0);
     TexCoord = aTexCoord;
-    gl_Position = vec4(aPos, 1.0f);
 }

--- a/shaders/default.vert
+++ b/shaders/default.vert
@@ -1,6 +1,7 @@
 #version 330 core
-layout (location = 0) in vec3 aPos;
-layout (location = 1) in vec2 aTexCoord;
+
+layout(location = 0) in vec3 aPos;
+layout(location = 1) in vec2 aTexCoord;
 
 out vec2 TexCoord;
 uniform mat4 proj_matrix;

--- a/src/mlx_images.c
+++ b/src/mlx_images.c
@@ -6,42 +6,49 @@
 /*   By: W2Wizard <w2.wizzard@gmail.com>              +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2022/01/21 15:34:45 by W2Wizard      #+#    #+#                 */
-/*   Updated: 2022/01/21 18:29:42 by W2Wizard      ########   odam.nl         */
+/*   Updated: 2022/01/21 20:33:39 by W2Wizard      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "MLX42/MLX42_Int.h"
 
 // TODO: Allow Z depth
-void	mlx_draw_image(t_mlx *mlx, t_mlx_image *img, uint16_t x, uint16_t y)
+void	mlx_draw_image(t_mlx *mlx, t_mlx_image *img, uint16_t x, uint16_t y, int32_t ZOffset)
 {
 	t_mlx_ctx		*mlxctx;
 	t_mlx_image_ctx	*imgctx;
 	const int32_t	w = img->width;
 	const int32_t	h = img->height;
 	const float		matrix[16] = {
-		2.f / w, 0, 0, 0,
-		0, 2. / -h, 0, 0,
-		0, 0, -2 / (1000 - -1000), 0,
-		-1, -(h / -h), -((1000 + -1000) / (1000 - -1000)), 1
+		2.f / mlx->width, 0, 0, 0,
+		0, 2. / -mlx->height, 0, 0,
+		0, 0, -2. / (1000. - -1000.), 0,
+		-1, -(mlx->height / -mlx->height),
+		-((1000. + -1000.) / (1000. - -1000.)), 1
 	};
+
+	x = y = 64;
 
 	mlxctx = mlx->context;
 	imgctx = img->context;
-	glUniformMatrix4fv(glGetUniformLocation(mlxctx->shaderprogram, \
-	"proj_matrix"), 1, GL_FALSE, matrix);
-	imgctx->vertices[0] = (t_vert){x, y, 0.f, 0.f, 0.f};
-	imgctx->vertices[1] = (t_vert){x + w, y + h, 0.f, 1.f, 1.f};
-	imgctx->vertices[2] = (t_vert){x + w, y, 0.f, 1.f, 0.f};
-	imgctx->vertices[3] = (t_vert){x, y, 0.f, 0.f, 0.f};
-	imgctx->vertices[4] = (t_vert){x, y + h, 0.f, 0.f, 1.f};
-	imgctx->vertices[5] = (t_vert){x + w, y + h, 0.f, 1.f, 1.f};
+	imgctx->vertices[0] = (t_vert){x, y, ZOffset, 0.f, 0.f};
+	imgctx->vertices[1] = (t_vert){x + w, y + h, ZOffset, 1.f, 1.f};
+	imgctx->vertices[2] = (t_vert){x + w, y, ZOffset, 1.f, 0.f};
+	imgctx->vertices[3] = (t_vert){x, y, ZOffset, 0.f, 0.f};
+	imgctx->vertices[4] = (t_vert){x, y + h, ZOffset, 0.f, 1.f};
+	imgctx->vertices[5] = (t_vert){x + w, y + h, ZOffset, 1.f, 1.f};
 	glActiveTexture(GL_TEXTURE0);
 	glBindTexture(GL_TEXTURE_2D, imgctx->texture);
 	glUseProgram(mlxctx->shaderprogram);
+	glUniformMatrix4fv(glGetUniformLocation(mlxctx->shaderprogram, \
+	"proj_matrix"), 1, GL_FALSE, matrix);
+	glUniform1i(glGetUniformLocation(mlxctx->shaderprogram, "outTexture"), 0);
 	glBindVertexArray(mlxctx->vao);
 	glBindBuffer(GL_ARRAY_BUFFER, mlxctx->vbo);
-	glBufferData(GL_ARRAY_BUFFER, sizeof(t_vert) * 6, &imgctx->vertices, GL_STATIC_DRAW);
+	glBufferData(GL_ARRAY_BUFFER, sizeof(t_vert) * 6, &imgctx->vertices, \
+	GL_STATIC_DRAW);
+	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, w, h, 0, GL_RGBA, \
+	GL_UNSIGNED_BYTE, img->pixels);
 	glDrawArrays(GL_TRIANGLES, 0, 6);
 }
 
@@ -60,7 +67,6 @@ t_mlx_image	*mlx_new_image(t_mlx *mlx, uint16_t width, uint16_t height)
 	newimg->pixels = malloc(width * height * sizeof(int32_t));
 	if (!newimg->pixels)
 		return ((void *)mlx_free_va(false, 2, newimg, newctx));
-	memset(newimg->pixels, 255, width * height * sizeof(int32_t));
 	glGenTextures(1, &newctx->texture);
 	glBindTexture(GL_TEXTURE_2D, newctx->texture);
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, \

--- a/src/mlx_images.c
+++ b/src/mlx_images.c
@@ -6,7 +6,7 @@
 /*   By: W2Wizard <w2.wizzard@gmail.com>              +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2022/01/21 15:34:45 by W2Wizard      #+#    #+#                 */
-/*   Updated: 2022/01/21 18:15:59 by W2Wizard      ########   odam.nl         */
+/*   Updated: 2022/01/21 18:29:42 by W2Wizard      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -45,7 +45,7 @@ void	mlx_draw_image(t_mlx *mlx, t_mlx_image *img, uint16_t x, uint16_t y)
 	glDrawArrays(GL_TRIANGLES, 0, 6);
 }
 
-t_mlx_image	*mlx_new_image(uint16_t width, uint16_t height)
+t_mlx_image	*mlx_new_image(t_mlx *mlx, uint16_t width, uint16_t height)
 {
 	t_mlx_image		*newimg;
 	t_mlx_image_ctx	*newctx;
@@ -67,5 +67,8 @@ t_mlx_image	*mlx_new_image(uint16_t width, uint16_t height)
 	GL_UNSIGNED_BYTE, newimg->pixels);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+	mlx_lstadd_back((t_mlx_list **)(&mlx->images), mlx_lstnew(newimg));
 	return (newimg);
 }

--- a/src/mlx_images.c
+++ b/src/mlx_images.c
@@ -6,17 +6,15 @@
 /*   By: W2Wizard <w2.wizzard@gmail.com>              +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2022/01/21 15:34:45 by W2Wizard      #+#    #+#                 */
-/*   Updated: 2022/01/21 20:33:39 by W2Wizard      ########   odam.nl         */
+/*   Updated: 2022/01/22 13:54:59 by W2Wizard      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "MLX42/MLX42_Int.h"
 
-// TODO: Allow Z depth
-void	mlx_draw_image(t_mlx *mlx, t_mlx_image *img, uint16_t x, uint16_t y, int32_t ZOffset)
+void	mlx_draw_texture(t_mlx_image *img, t_mlx_ctx *mlxctx, \
+t_mlx_image_ctx *imgctx, t_mlx *mlx)
 {
-	t_mlx_ctx		*mlxctx;
-	t_mlx_image_ctx	*imgctx;
 	const int32_t	w = img->width;
 	const int32_t	h = img->height;
 	const float		matrix[16] = {
@@ -27,18 +25,6 @@ void	mlx_draw_image(t_mlx *mlx, t_mlx_image *img, uint16_t x, uint16_t y, int32_
 		-((1000. + -1000.) / (1000. - -1000.)), 1
 	};
 
-	x = y = 64;
-
-	mlxctx = mlx->context;
-	imgctx = img->context;
-	imgctx->vertices[0] = (t_vert){x, y, ZOffset, 0.f, 0.f};
-	imgctx->vertices[1] = (t_vert){x + w, y + h, ZOffset, 1.f, 1.f};
-	imgctx->vertices[2] = (t_vert){x + w, y, ZOffset, 1.f, 0.f};
-	imgctx->vertices[3] = (t_vert){x, y, ZOffset, 0.f, 0.f};
-	imgctx->vertices[4] = (t_vert){x, y + h, ZOffset, 0.f, 1.f};
-	imgctx->vertices[5] = (t_vert){x + w, y + h, ZOffset, 1.f, 1.f};
-	glActiveTexture(GL_TEXTURE0);
-	glBindTexture(GL_TEXTURE_2D, imgctx->texture);
 	glUseProgram(mlxctx->shaderprogram);
 	glUniformMatrix4fv(glGetUniformLocation(mlxctx->shaderprogram, \
 	"proj_matrix"), 1, GL_FALSE, matrix);
@@ -50,6 +36,28 @@ void	mlx_draw_image(t_mlx *mlx, t_mlx_image *img, uint16_t x, uint16_t y, int32_
 	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, w, h, 0, GL_RGBA, \
 	GL_UNSIGNED_BYTE, img->pixels);
 	glDrawArrays(GL_TRIANGLES, 0, 6);
+}
+
+void	mlx_draw_image(t_mlx *mlx, t_mlx_image *img, uint16_t x, uint16_t y)
+{
+	t_mlx_ctx		*mlxctx;
+	t_mlx_image_ctx	*imgctx;
+	const int32_t	w = img->width;
+	const int32_t	h = img->height;
+
+	img->x = x;
+	img->y = y;
+	mlxctx = mlx->context;
+	imgctx = img->context;
+	imgctx->vertices[0] = (t_vert){x, y, 1.0f, 0.f, 0.f};
+	imgctx->vertices[1] = (t_vert){x + w, y + h, 1.0f, 1.f, 1.f};
+	imgctx->vertices[2] = (t_vert){x + w, y, 1.0f, 1.f, 0.f};
+	imgctx->vertices[3] = (t_vert){x, y, 1.0f, 0.f, 0.f};
+	imgctx->vertices[4] = (t_vert){x, y + h, 1.0f, 0.f, 1.f};
+	imgctx->vertices[5] = (t_vert){x + w, y + h, 1.0f, 1.f, 1.f};
+	glActiveTexture(GL_TEXTURE0);
+	glBindTexture(GL_TEXTURE_2D, imgctx->texture);
+	mlx_draw_texture(img, mlxctx, imgctx, mlx);
 }
 
 t_mlx_image	*mlx_new_image(t_mlx *mlx, uint16_t width, uint16_t height)

--- a/src/mlx_images.c
+++ b/src/mlx_images.c
@@ -1,0 +1,71 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        ::::::::            */
+/*   mlx_images.c                                       :+:    :+:            */
+/*                                                     +:+                    */
+/*   By: W2Wizard <w2.wizzard@gmail.com>              +#+                     */
+/*                                                   +#+                      */
+/*   Created: 2022/01/21 15:34:45 by W2Wizard      #+#    #+#                 */
+/*   Updated: 2022/01/21 18:15:59 by W2Wizard      ########   odam.nl         */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "MLX42/MLX42_Int.h"
+
+// TODO: Allow Z depth
+void	mlx_draw_image(t_mlx *mlx, t_mlx_image *img, uint16_t x, uint16_t y)
+{
+	t_mlx_ctx		*mlxctx;
+	t_mlx_image_ctx	*imgctx;
+	const int32_t	w = img->width;
+	const int32_t	h = img->height;
+	const float		matrix[16] = {
+		2.f / w, 0, 0, 0,
+		0, 2. / -h, 0, 0,
+		0, 0, -2 / (1000 - -1000), 0,
+		-1, -(h / -h), -((1000 + -1000) / (1000 - -1000)), 1
+	};
+
+	mlxctx = mlx->context;
+	imgctx = img->context;
+	glUniformMatrix4fv(glGetUniformLocation(mlxctx->shaderprogram, \
+	"proj_matrix"), 1, GL_FALSE, matrix);
+	imgctx->vertices[0] = (t_vert){x, y, 0.f, 0.f, 0.f};
+	imgctx->vertices[1] = (t_vert){x + w, y + h, 0.f, 1.f, 1.f};
+	imgctx->vertices[2] = (t_vert){x + w, y, 0.f, 1.f, 0.f};
+	imgctx->vertices[3] = (t_vert){x, y, 0.f, 0.f, 0.f};
+	imgctx->vertices[4] = (t_vert){x, y + h, 0.f, 0.f, 1.f};
+	imgctx->vertices[5] = (t_vert){x + w, y + h, 0.f, 1.f, 1.f};
+	glActiveTexture(GL_TEXTURE0);
+	glBindTexture(GL_TEXTURE_2D, imgctx->texture);
+	glUseProgram(mlxctx->shaderprogram);
+	glBindVertexArray(mlxctx->vao);
+	glBindBuffer(GL_ARRAY_BUFFER, mlxctx->vbo);
+	glBufferData(GL_ARRAY_BUFFER, sizeof(t_vert) * 6, &imgctx->vertices, GL_STATIC_DRAW);
+	glDrawArrays(GL_TRIANGLES, 0, 6);
+}
+
+t_mlx_image	*mlx_new_image(uint16_t width, uint16_t height)
+{
+	t_mlx_image		*newimg;
+	t_mlx_image_ctx	*newctx;
+
+	newimg = calloc(1, sizeof(t_mlx_image));
+	newctx = calloc(1, sizeof(t_mlx_image_ctx));
+	if (!newimg || !newctx)
+		return (NULL);
+	newimg->width = width;
+	newimg->height = height;
+	newimg->context = newctx;
+	newimg->pixels = malloc(width * height * sizeof(int32_t));
+	if (!newimg->pixels)
+		return ((void *)mlx_free_va(false, 2, newimg, newctx));
+	memset(newimg->pixels, 255, width * height * sizeof(int32_t));
+	glGenTextures(1, &newctx->texture);
+	glBindTexture(GL_TEXTURE_2D, newctx->texture);
+	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, \
+	GL_UNSIGNED_BYTE, newimg->pixels);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+	return (newimg);
+}

--- a/src/mlx_images.c
+++ b/src/mlx_images.c
@@ -6,7 +6,7 @@
 /*   By: W2Wizard <w2.wizzard@gmail.com>              +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2022/01/21 15:34:45 by W2Wizard      #+#    #+#                 */
-/*   Updated: 2022/01/22 14:31:56 by W2Wizard      ########   odam.nl         */
+/*   Updated: 2022/01/22 16:21:30 by W2Wizard      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -39,23 +39,24 @@ t_mlx_image_ctx *imgctx, t_mlx *mlx)
 	glDrawArrays(GL_TRIANGLES, 0, 6);
 }
 
-void	mlx_draw_image(t_mlx *mlx, t_mlx_image *img, uint16_t x, uint16_t y)
+void	mlx_draw_image(t_mlx *mlx, t_mlx_image *img, int32_t x, int32_t y)
 {
 	t_mlx_ctx		*mlxctx;
 	t_mlx_image_ctx	*imgctx;
 	const int32_t	w = img->width;
 	const int32_t	h = img->height;
+	const int32_t	z = img->depth;
 
 	img->x = x;
 	img->y = y;
 	mlxctx = mlx->context;
 	imgctx = img->context;
-	imgctx->vertices[0] = (t_vert){x, y, 1.0f, 0.f, 0.f};
-	imgctx->vertices[1] = (t_vert){x + w, y + h, 1.0f, 1.f, 1.f};
-	imgctx->vertices[2] = (t_vert){x + w, y, 1.0f, 1.f, 0.f};
-	imgctx->vertices[3] = (t_vert){x, y, 1.0f, 0.f, 0.f};
-	imgctx->vertices[4] = (t_vert){x, y + h, 1.0f, 0.f, 1.f};
-	imgctx->vertices[5] = (t_vert){x + w, y + h, 1.0f, 1.f, 1.f};
+	imgctx->vertices[0] = (t_vert){x, y, z, 0.f, 0.f};
+	imgctx->vertices[1] = (t_vert){x + w, y + h, z, 1.f, 1.f};
+	imgctx->vertices[2] = (t_vert){x + w, y, z, 1.f, 0.f};
+	imgctx->vertices[3] = (t_vert){x, y, z, 0.f, 0.f};
+	imgctx->vertices[4] = (t_vert){x, y + h, z, 0.f, 1.f};
+	imgctx->vertices[5] = (t_vert){x + w, y + h, z, 1.f, 1.f};
 	glActiveTexture(GL_TEXTURE0);
 	glBindTexture(GL_TEXTURE_2D, imgctx->texture);
 	mlx_draw_texture(img, mlxctx, imgctx, mlx);

--- a/src/mlx_images.c
+++ b/src/mlx_images.c
@@ -6,13 +6,14 @@
 /*   By: W2Wizard <w2.wizzard@gmail.com>              +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2022/01/21 15:34:45 by W2Wizard      #+#    #+#                 */
-/*   Updated: 2022/01/22 13:54:59 by W2Wizard      ########   odam.nl         */
+/*   Updated: 2022/01/22 14:31:56 by W2Wizard      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "MLX42/MLX42_Int.h"
 
-void	mlx_draw_texture(t_mlx_image *img, t_mlx_ctx *mlxctx, \
+// Reference: https://bit.ly/3KuHOu1 (Matrix View Projection)
+static void	mlx_draw_texture(t_mlx_image *img, t_mlx_ctx *mlxctx, \
 t_mlx_image_ctx *imgctx, t_mlx *mlx)
 {
 	const int32_t	w = img->width;

--- a/src/mlx_init.c
+++ b/src/mlx_init.c
@@ -6,7 +6,7 @@
 /*   By: W2Wizard <w2.wizzard@gmail.com>              +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2021/12/28 00:24:30 by W2Wizard      #+#    #+#                 */
-/*   Updated: 2022/01/21 20:28:09 by W2Wizard      ########   odam.nl         */
+/*   Updated: 2022/01/22 13:58:09 by W2Wizard      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -80,7 +80,7 @@ t_mlx	*mlx_init(int32_t Width, int32_t Height, const char *Title, bool Resize)
 	glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
 	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
 	glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
-	if (IS_APPLE)
+	if (__APPLE__)
 		glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
 	glfwWindowHint(GLFW_RESIZABLE, Resize);
 	mlx->width = Width;

--- a/src/mlx_init.c
+++ b/src/mlx_init.c
@@ -6,7 +6,7 @@
 /*   By: W2Wizard <w2.wizzard@gmail.com>              +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2021/12/28 00:24:30 by W2Wizard      #+#    #+#                 */
-/*   Updated: 2022/01/19 15:21:42 by lde-la-h      ########   odam.nl         */
+/*   Updated: 2022/01/21 18:21:28 by W2Wizard      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,59 +18,22 @@ static void	framebuffer_callback(GLFWwindow *window, int width, int height)
 	glViewport(0, 0, width, height);
 }
 
-static bool	mlx_draw_frame(t_mlx *mlx)
-{
-	t_mlx_ctx		*context;
-
-	context = mlx->context;
-	glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 32, NULL);
-	glEnableVertexAttribArray(0);
-	glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, 32, (void *)12);
-	glEnableVertexAttribArray(1);
-	glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, 32, (void *)24);
-	glEnableVertexAttribArray(2);
-	glGenTextures(1, &(context->texture));
-	glBindTexture(GL_TEXTURE_2D, context->texture);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-	mlx->pixels = calloc((mlx->width * mlx->height), sizeof(int32_t));
-	if (!mlx->pixels)
-		return (false);
-	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, mlx->width, mlx->height, \
-	0, GL_RGBA, GL_UNSIGNED_BYTE, mlx->pixels);
-	glUniform1i(glGetUniformLocation(context->shaderprogram, "texture"), 0);
-	glEnable(GL_BLEND);
-	glBlendEquation(GL_FUNC_ADD);
-	return (true);
-}
-
 static bool	mlx_init_frame(t_mlx *mlx)
 {
 	t_mlx_ctx		*context;
-	const float		vertices[] = {
-		// Positions            // Colors           // Texture coords
-		-1.0f, +1.0f, 0.0f,		1.0f, 1.0f, 0.0f,	0.0f, 0.0f, // Top left 
-		-1.0f, -1.0f, 0.0f,		0.0f, 0.0f, 1.0f,	0.0f, 1.0f, // Bottom left
-		+1.0f, -1.0f, 0.0f,		0.0f, 1.0f, 0.0f,	1.0f, 1.0f, // Bottom right
-		+1.0f, +1.0f, 0.0f,		1.0f, 0.0f, 0.0f,	1.0f, 0.0f, // Top right
-	};
-	const uint32_t	index[] = {
-		0, 1, 3, // First triangle
-		1, 2, 3, // Second triangle
-	};
 
 	context = mlx->context;
 	glGenVertexArrays(1, &(context->vao));
 	glGenBuffers(1, &(context->vbo));
 	glGenBuffers(1, &(context->ebo));
 	glBindVertexArray(context->vao);
-	glBindBuffer(GL_ARRAY_BUFFER, context->vbo);
-	glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW);
-	glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, context->ebo);
-	glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(index), index, GL_STATIC_DRAW);
-	return (mlx_draw_frame(mlx));
+	glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 32, NULL);
+	glEnableVertexAttribArray(0);
+	glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 32, (void *)12);
+	glEnableVertexAttribArray(1);
+	glEnable(GL_BLEND);
+	glBlendEquation(GL_FUNC_ADD);
+	return (true);
 }
 
 /**

--- a/src/mlx_init.c
+++ b/src/mlx_init.c
@@ -6,7 +6,7 @@
 /*   By: W2Wizard <w2.wizzard@gmail.com>              +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2021/12/28 00:24:30 by W2Wizard      #+#    #+#                 */
-/*   Updated: 2022/01/21 18:21:28 by W2Wizard      ########   odam.nl         */
+/*   Updated: 2022/01/21 20:28:09 by W2Wizard      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,11 +25,12 @@ static bool	mlx_init_frame(t_mlx *mlx)
 	context = mlx->context;
 	glGenVertexArrays(1, &(context->vao));
 	glGenBuffers(1, &(context->vbo));
-	glGenBuffers(1, &(context->ebo));
 	glBindVertexArray(context->vao);
-	glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 32, NULL);
+	glBindBuffer(GL_ARRAY_BUFFER, context->vbo);
+	glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(t_vert), NULL);
 	glEnableVertexAttribArray(0);
-	glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 32, (void *)12);
+	glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, sizeof(t_vert), \
+	(void *)(sizeof(float) * 3));
 	glEnableVertexAttribArray(1);
 	glEnable(GL_BLEND);
 	glBlendEquation(GL_FUNC_ADD);
@@ -48,7 +49,7 @@ static bool	mlx_init_render(t_mlx *mlx)
 		return (mlx_error(GLFW_WIN_FAILURE));
 	glfwMakeContextCurrent(mlx->window);
 	glfwSetFramebufferSizeCallback(mlx->window, framebuffer_callback);
-	glfwSwapInterval(true);
+	glfwSwapInterval(1);
 	{
 		if (!gladLoadGLLoader((GLADloadproc)glfwGetProcAddress))
 			return (mlx_error(GLFW_GLAD_FAILURE));

--- a/src/mlx_loop.c
+++ b/src/mlx_loop.c
@@ -6,7 +6,7 @@
 /*   By: W2Wizard <w2.wizzard@gmail.com>              +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2021/12/28 01:24:36 by W2Wizard      #+#    #+#                 */
-/*   Updated: 2022/01/21 18:10:47 by W2Wizard      ########   odam.nl         */
+/*   Updated: 2022/01/21 20:20:19 by W2Wizard      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -46,19 +46,20 @@ bool	mlx_loop_hook(t_mlx *mlx, void (*f)(void *), void *param)
 	return (true);
 }
 
-static bool	mlx_handle_resize(t_mlx *mlx)
+static bool	mlx_handle_resize(t_mlx *mlx, t_mlx_image *img)
 {
-	const int32_t	old_width = mlx->width;
-	const int32_t	old_height = mlx->height;
+	const int32_t	old_width = img->width;
+	const int32_t	old_height = img->height;
 
 	glfwGetWindowSize(mlx->window, &(mlx->width), &(mlx->height));
-	if (mlx->width != old_width || mlx->height != old_height)
+	if (img->width != old_width || img->height != old_height)
 	{
-		mlx->pixels = realloc(mlx->pixels, \
-		(mlx->width * mlx->height) * sizeof(int32_t));
-		if (mlx->pixels == NULL)
+		printf("SETWEGWIEGJIWEG\n");
+		img->pixels = realloc(img->pixels, \
+		(img->width * img->height) * sizeof(int32_t));
+		if (img->pixels == NULL)
 			return (false);
-		memset(mlx->pixels, 0, (mlx->width * mlx->height) * sizeof(int32_t));
+		memset(img->pixels, 0, (img->width * img->height) * sizeof(int32_t));
 	}
 	return (true);
 }
@@ -76,11 +77,8 @@ static void	mlx_render_images(t_mlx *mlx)
 	{
 		img = images->content;
 		imgctx = img->context;
-		glActiveTexture(imgctx->texture);
-		glBindTexture(GL_TEXTURE_2D, imgctx->texture);
-		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, mlx->width, mlx->height, \
-		0, GL_RGBA, GL_UNSIGNED_BYTE, mlx->pixels);
-		glUniform1i(glGetUniformLocation(mlxctx->shaderprogram, "texture"), 0);
+		mlx_handle_resize(mlx, img);
+		mlx_draw_image(mlx, img, 0, 0, 0);
 		images = images->next;
 	}
 }
@@ -95,15 +93,10 @@ void	mlx_loop(t_mlx *mlx)
 	glEnable(GL_DEPTH_TEST);
 	while (!glfwWindowShouldClose(mlx->window))
 	{
-		if (!mlx_handle_resize(mlx))
-		{
-			mlx_quit(mlx);
-			mlx_error(MLX_MEMORY_FAIL);
-			break ;
-		}
 		start = glfwGetTime();
 		mlx->delta_time = start - oldstart;
 		oldstart = start;
+		glClearColor(1.0f, 0.2f, 0.2f, 1.0f);
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 		mlx_exec_loop_hooks(mlx);
 		mlx_render_images(mlx);

--- a/src/mlx_loop.c
+++ b/src/mlx_loop.c
@@ -6,7 +6,7 @@
 /*   By: W2Wizard <w2.wizzard@gmail.com>              +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2021/12/28 01:24:36 by W2Wizard      #+#    #+#                 */
-/*   Updated: 2022/01/22 14:04:27 by W2Wizard      ########   odam.nl         */
+/*   Updated: 2022/01/22 14:52:08 by W2Wizard      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -46,15 +46,14 @@ bool	mlx_loop_hook(t_mlx *mlx, void (*f)(void *), void *param)
 	return (true);
 }
 
+/*
 static bool	mlx_handle_resize(t_mlx *mlx, t_mlx_image *img)
 {
 	const int32_t	old_width = img->width;
 	const int32_t	old_height = img->height;
 
-	glfwGetWindowSize(mlx->window, &(mlx->width), &(mlx->height));
 	if (img->width != old_width || img->height != old_height)
 	{
-		printf("SETWEGWIEGJIWEG\n");
 		img->pixels = realloc(img->pixels, \
 		(img->width * img->height) * sizeof(int32_t));
 		if (img->pixels == NULL)
@@ -63,6 +62,7 @@ static bool	mlx_handle_resize(t_mlx *mlx, t_mlx_image *img)
 	}
 	return (true);
 }
+*/
 
 static void	mlx_render_images(t_mlx *mlx)
 {
@@ -76,8 +76,7 @@ static void	mlx_render_images(t_mlx *mlx)
 	while (images)
 	{
 		img = images->content;
-		imgctx = img->context;
-		mlx_handle_resize(mlx, img);
+		imgctx = img->context;\
 		mlx_draw_image(mlx, img, img->x, img->y);
 		images = images->next;
 	}
@@ -101,6 +100,7 @@ void	mlx_loop(t_mlx *mlx)
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 		mlx_exec_loop_hooks(mlx);
 		mlx_render_images(mlx);
+		glfwGetWindowSize(mlx->window, &(mlx->width), &(mlx->height));
 		glfwSwapBuffers(mlx->window);
 		glfwPollEvents();
 	}

--- a/src/mlx_loop.c
+++ b/src/mlx_loop.c
@@ -6,7 +6,7 @@
 /*   By: W2Wizard <w2.wizzard@gmail.com>              +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2021/12/28 01:24:36 by W2Wizard      #+#    #+#                 */
-/*   Updated: 2022/01/21 20:20:19 by W2Wizard      ########   odam.nl         */
+/*   Updated: 2022/01/22 14:04:27 by W2Wizard      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -78,7 +78,7 @@ static void	mlx_render_images(t_mlx *mlx)
 		img = images->content;
 		imgctx = img->context;
 		mlx_handle_resize(mlx, img);
-		mlx_draw_image(mlx, img, 0, 0, 0);
+		mlx_draw_image(mlx, img, img->x, img->y);
 		images = images->next;
 	}
 }
@@ -91,6 +91,7 @@ void	mlx_loop(t_mlx *mlx)
 
 	oldstart = 0;
 	glEnable(GL_DEPTH_TEST);
+	//glPolygonMode( GL_FRONT_AND_BACK, GL_LINE );
 	while (!glfwWindowShouldClose(mlx->window))
 	{
 		start = glfwGetTime();

--- a/src/mlx_loop.c
+++ b/src/mlx_loop.c
@@ -6,7 +6,7 @@
 /*   By: W2Wizard <w2.wizzard@gmail.com>              +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2021/12/28 01:24:36 by W2Wizard      #+#    #+#                 */
-/*   Updated: 2022/01/22 14:52:08 by W2Wizard      ########   odam.nl         */
+/*   Updated: 2022/01/22 16:05:29 by W2Wizard      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -62,7 +62,6 @@ static bool	mlx_handle_resize(t_mlx *mlx, t_mlx_image *img)
 	}
 	return (true);
 }
-*/
 
 static void	mlx_render_images(t_mlx *mlx)
 {
@@ -81,8 +80,10 @@ static void	mlx_render_images(t_mlx *mlx)
 		images = images->next;
 	}
 }
+*/
 
 // Essentially just loops forever and executes the hooks and window size.
+// glPolygonMode( GL_FRONT_AND_BACK, GL_LINE );
 void	mlx_loop(t_mlx *mlx)
 {
 	double		start;
@@ -90,17 +91,15 @@ void	mlx_loop(t_mlx *mlx)
 
 	oldstart = 0;
 	glEnable(GL_DEPTH_TEST);
-	//glPolygonMode( GL_FRONT_AND_BACK, GL_LINE );
 	while (!glfwWindowShouldClose(mlx->window))
 	{
 		start = glfwGetTime();
 		mlx->delta_time = start - oldstart;
 		oldstart = start;
-		glClearColor(1.0f, 0.2f, 0.2f, 1.0f);
+		glClearColor(0.2f, 0.2f, 0.2f, 1.0f);
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-		mlx_exec_loop_hooks(mlx);
-		mlx_render_images(mlx);
 		glfwGetWindowSize(mlx->window, &(mlx->width), &(mlx->height));
+		mlx_exec_loop_hooks(mlx);
 		glfwSwapBuffers(mlx->window);
 		glfwPollEvents();
 	}

--- a/src/mlx_monitor.c
+++ b/src/mlx_monitor.c
@@ -6,7 +6,7 @@
 /*   By: lde-la-h <lde-la-h@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2022/01/19 17:18:59 by lde-la-h      #+#    #+#                 */
-/*   Updated: 2022/01/19 17:53:15 by lde-la-h      ########   odam.nl         */
+/*   Updated: 2022/01/20 00:37:23 by W2Wizard      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,9 +24,9 @@ void	mlx_get_window_pos(t_mlx *mlx, int32_t *xpos, int32_t *ypos)
 
 void	mlx_get_monitor_size(int32_t index, int32_t *width, int32_t *height)
 {
-	GLFWvidmode	*vidmode;
-	GLFWmonitor	**monitors;
-	int32_t		monitor_count;
+	const GLFWvidmode	*vidmode;
+	GLFWmonitor			**monitors;
+	int32_t				monitor_count;
 
 	monitors = glfwGetMonitors(&monitor_count);
 	if (index > monitor_count || !monitors)

--- a/src/mlx_mouse.c
+++ b/src/mlx_mouse.c
@@ -6,7 +6,7 @@
 /*   By: W2Wizard <w2.wizzard@gmail.com>              +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2022/01/01 23:20:13 by W2Wizard      #+#    #+#                 */
-/*   Updated: 2022/01/19 15:05:47 by lde-la-h      ########   odam.nl         */
+/*   Updated: 2022/01/21 16:35:52 by W2Wizard      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,6 +15,8 @@
 /**
  * HACK: Questionable way of intercepting and adding additional custom params 
  * to the glfw mouse scroll callback function.
+ * 
+ * TODO: Use glfwSetWindowPointer!
  */
 
 static void				*g_param_cb = NULL;

--- a/src/mlx_put_pixel.c
+++ b/src/mlx_put_pixel.c
@@ -6,17 +6,17 @@
 /*   By: W2Wizard <w2.wizzard@gmail.com>              +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2021/12/28 03:30:13 by W2Wizard      #+#    #+#                 */
-/*   Updated: 2022/01/05 16:06:46 by W2Wizard      ########   odam.nl         */
+/*   Updated: 2022/01/22 15:15:21 by W2Wizard      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "MLX42/MLX42_Int.h"
 
-void	mlx_putpixel(t_mlx *MLX, int32_t X, int32_t Y, int32_t Color)
+void	mlx_putpixel(t_mlx_image *img, int32_t X, int32_t Y, int32_t Color)
 {
 	uint8_t	*pixelstart;
 
-	pixelstart = &MLX->pixels[(Y * MLX->width + X) * sizeof(int32_t)];
+	pixelstart = &img->pixels[(Y * img->width + X) * sizeof(int32_t)];
 	*(pixelstart + 0) = (uint8_t)((Color >> 24) & 0xFF);
 	*(pixelstart + 1) = (uint8_t)((Color >> 16) & 0xFF);
 	*(pixelstart + 2) = (uint8_t)((Color >> 8) & 0xFF);

--- a/src/mlx_terminate.c
+++ b/src/mlx_terminate.c
@@ -6,12 +6,13 @@
 /*   By: W2Wizard <w2.wizzard@gmail.com>              +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2021/12/28 02:43:22 by W2Wizard      #+#    #+#                 */
-/*   Updated: 2022/01/06 18:10:10 by W2Wizard      ########   odam.nl         */
+/*   Updated: 2022/01/21 18:24:41 by W2Wizard      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "MLX42/MLX42_Int.h"
 
+// TODO: Delete images!
 void	mlx_terminate(t_mlx *mlx)
 {
 	t_mlx_ctx	*context;
@@ -19,7 +20,7 @@ void	mlx_terminate(t_mlx *mlx)
 	context = mlx->context;
 	mlx_lstclear((t_mlx_list **)(&mlx->hooks), &free);
 	glDeleteProgram(context->shaderprogram);
-	glDeleteTextures(1, &(context->texture));
+	//glDeleteTextures(1, &(context->texture));
 	glDeleteBuffers(1, &(context->vbo));
 	free(mlx);
 	glfwTerminate();


### PR DESCRIPTION
# Fancy Images!

![image](https://user-images.githubusercontent.com/63303990/150645754-7f97c77e-2388-40c5-bfb9-cda9743b12b4.png)

To keep compatibility with the original minilibx, it was suggested that I should support images.
This PR introduces that feature by completely removing the old system of a single texture and now having
multiple textures.

Special thanks to @Techdaan for helping me and sharing some very useful OpenGL knowledge!