### PR TITLE
Improve rendering mechanics for putting strings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,17 +6,19 @@
 #    By: W2Wizard <w2.wizzard@gmail.com>              +#+                      #
 #                                                    +#+                       #
 #    Created: 2022/02/26 21:32:49 by W2Wizard      #+#    #+#                  #
-#    Updated: 2022/02/28 12:57:03 by lde-la-h      ########   odam.nl          #
+#    Updated: 2022/02/28 17:55:05 by lde-la-h      ########   odam.nl          #
 #                                                                              #
 # **************************************************************************** #
 
 NAME	= libmlx42.a
-CFLAGS	= -Wextra -Wall -Wunreachable-code -Wno-char-subscripts -Ofast
+CFLAGS	= -Wextra -Wall -Wunreachable-code -Wno-char-subscripts
 ifndef NOWARNING
 CFLAGS	+= -Werror
 endif
 ifdef DEBUG
 CFLAGS	+= -g
+else
+CFLAGS	+= -Ofast
 endif
 
 ifeq ($(OS), Windows_NT)

--- a/include/MLX42/MLX42.h
+++ b/include/MLX42/MLX42.h
@@ -6,7 +6,7 @@
 /*   By: W2Wizard <w2.wizzard@gmail.com>              +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2021/12/28 00:33:01 by W2Wizard      #+#    #+#                 */
-/*   Updated: 2022/02/22 20:58:30 by lde-la-h      ########   odam.nl         */
+/*   Updated: 2022/02/28 13:05:15 by lde-la-h      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -577,6 +577,6 @@ uint32_t nheight);
  * @param x The X location.
  * @param y The Y location.
  */
-void		mlx_put_string(t_mlx *mlx, char *str, int32_t x, int32_t y);
+t_mlx_image	*mlx_put_string(t_mlx *mlx, const char *str, int32_t x, int32_t y);
 
 #endif

--- a/include/MLX42/MLX42.h
+++ b/include/MLX42/MLX42.h
@@ -6,7 +6,7 @@
 /*   By: W2Wizard <w2.wizzard@gmail.com>              +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2021/12/28 00:33:01 by W2Wizard      #+#    #+#                 */
-/*   Updated: 2022/02/28 13:05:15 by lde-la-h      ########   odam.nl         */
+/*   Updated: 2022/02/28 15:46:12 by lde-la-h      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -533,6 +533,9 @@ t_mlx_image	*mlx_new_image(t_mlx *mlx, uint32_t width, uint32_t height);
  * Draws a new instance of an image, it will then share the same
  * pixel buffer as the image.
  * 
+ * WARNING: Try to display as few images onto the window as possible,
+ * drawing too many images will cause a loss in peformance!
+ * 
  * @param[in] mlx The MLX instance handle.
  * @param[in] img The image to draw onto the screen.
  * @param[in] x The X position.
@@ -570,12 +573,13 @@ uint32_t nheight);
 //= String Functions =//
 
 /**
- * Draws a string onto the screen.
+ * Draws a string onto an image and then outputs it onto the window.
  * 
  * @param mlx The MLX instance handle.
  * @param str The string to draw.
  * @param x The X location.
  * @param y The Y location.
+ * @return Image ptr to the string.
  */
 t_mlx_image	*mlx_put_string(t_mlx *mlx, const char *str, int32_t x, int32_t y);
 

--- a/src/font/mlx_font.c
+++ b/src/font/mlx_font.c
@@ -6,37 +6,69 @@
 /*   By: W2Wizard <w2.wizzard@gmail.com>              +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2022/02/22 12:01:37 by W2Wizard      #+#    #+#                 */
-/*   Updated: 2022/02/28 13:20:33 by lde-la-h      ########   odam.nl         */
+/*   Updated: 2022/02/28 15:26:31 by lde-la-h      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "font.h"
 #include "MLX42/MLX42_Int.h"
 
+/**
+ * Retrieves the X offset of the given char in the font texture strip.
+ * 
+ * NOTE: Cheesy branchless operation :D
+ * 
+ * @param c The char to find.
+ * @return Non-negative if found or -1 if not found.
+ */
+static int32_t	mlx_get_texoffset(char c)
+{
+	const bool	_isprint = isprint(c);
+
+	return (-1 * (!_isprint) + ((FONT_WIDTH + 2) * (c - 32)) * (_isprint));
+}
+
+/**
+ * Does the actual copying of pixels form the atlas buffer to the
+ * image buffer.
+ * 
+ * Skips any non-printable characters.
+ * 
+ * @param image The image to draw on.
+ * @param texture The font_atlas.
+ * @param texoffset The character texture X offset.
+ * @param imgoffset The image X offset.
+ */
 static void	mlx_draw_font(t_mlx_image *image, const t_mlx_texture *texture, \
 int32_t texoffset, int32_t imgoffset)
 {
-	uint32_t	y;
-	uint32_t	bpp;
-	uint8_t		*pixelx;
-	uint8_t		*pixeli;
+	uint32_t		y;
+	uint8_t			*pixelx;
+	uint8_t			*pixeli;
+	const uint32_t	bpp = texture->bytes_per_pixel;
 
 	y = 0;
-	bpp = texture->bytes_per_pixel;
+	if (texoffset < 0)
+		return ;
 	while (y < FONT_HEIGHT)
 	{
-		pixelx = &texture->pixels[(y * texture->width + texoffset) * bpp];
-		pixeli = &image->pixels[(y * image->width + imgoffset) * bpp];
-		memmove(pixeli, pixelx, FONT_WIDTH * bpp);
+		pixelx = texture->pixels + ((y * texture->width + texoffset) * bpp);
+		pixeli = image->pixels + ((y * image->width + imgoffset) * bpp);
+		memcpy(pixeli, pixelx, FONT_WIDTH * bpp);
 		y++;
 	}
 }
 
-static bool	mlx_draw_text(const char *str, t_mlx_image *image)
+/**
+ * Draws the given text onto an image.
+ * 
+ * @param str The string to draw.
+ * @param image The target image.
+ */
+static void	mlx_draw_text(const char *str, t_mlx_image *image)
 {
 	size_t				i;
 	int32_t				imgoffset;
-	int32_t				texoffset;
 	const t_mlx_tex		atlas = {
 		font_atlas.width,
 		font_atlas.height,
@@ -48,24 +80,18 @@ static bool	mlx_draw_text(const char *str, t_mlx_image *image)
 	imgoffset = 0;
 	while (str[i])
 	{
-		// Get character offset in the atlas texture
-		texoffset = (FONT_WIDTH + 2) * (str[i] - 32);
-		//printf("Draw: %c Pos: %d %d | CharOffset @ %d\n", str[i], imgoffset, 0, texoffset);
-		mlx_draw_font(image, &atlas, texoffset, imgoffset);
+		mlx_draw_font(image, &atlas, mlx_get_texoffset(str[i++]), imgoffset);
 		imgoffset += FONT_WIDTH;
-		i++;
 	}
-	return (true);
 }
 
 t_mlx_image	*mlx_put_string(t_mlx *mlx, const char *str, int32_t x, int32_t y)
 {
-	int32_t		total_width;
 	t_mlx_image	*strimage;
 
-	total_width = strlen(str) * (FONT_WIDTH);
-	//printf("Draw img with width: %d\n", total_width);
-	strimage = mlx_new_image(mlx, total_width, FONT_HEIGHT);
+	if (!mlx || !str)
+		return (NULL);
+	strimage = mlx_new_image(mlx, strlen(str) * FONT_WIDTH, FONT_HEIGHT);
 	if (!strimage)
 		return (NULL);
 	mlx_draw_text(str, strimage);

--- a/src/mlx_images.c
+++ b/src/mlx_images.c
@@ -6,7 +6,7 @@
 /*   By: W2Wizard <w2.wizzard@gmail.com>              +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2022/01/21 15:34:45 by W2Wizard      #+#    #+#                 */
-/*   Updated: 2022/02/27 21:06:47 by W2Wizard      ########   odam.nl         */
+/*   Updated: 2022/02/28 18:52:43 by lde-la-h      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -107,19 +107,17 @@ void	mlx_delete_image(t_mlx *mlx, t_mlx_image *image)
 	t_mlx_list		*quelst;
 	t_mlx_ctx		*mlxctx;
 
+	if (!mlx)
+		return ;
 	mlxctx = mlx->context;
 	imglst = mlx_lstremove(&mlxctx->images, image, &mlx_equal_image);
+	quelst = mlx_lstremove(&mlxctx->render_queue, image, &mlx_equal_inst);
+	if (quelst)
+		mlx_freen(2, quelst->content, quelst);
 	if (imglst)
 	{
 		glDeleteTextures(1, &((t_mlx_image_ctx *)image->context)->texture);
-		mlx_freen(3, image->pixels, image->instances, image->context);
-		free(imglst);
+		mlx_freen(4, image->pixels, image->instances, image->context, imglst);
+		free(image);
 	}
-	quelst = mlx_lstremove(&mlxctx->render_queue, image, &mlx_equal_inst);
-	if (quelst)
-	{
-		free(quelst->content);
-		free(quelst);
-	}
-	free(image);
 }

--- a/src/mlx_init.c
+++ b/src/mlx_init.c
@@ -6,7 +6,7 @@
 /*   By: W2Wizard <w2.wizzard@gmail.com>              +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2021/12/28 00:24:30 by W2Wizard      #+#    #+#                 */
-/*   Updated: 2022/02/27 19:50:58 by W2Wizard      ########   odam.nl         */
+/*   Updated: 2022/02/28 13:05:44 by lde-la-h      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,8 +38,6 @@ static bool	mlx_create_buffers(t_mlx *mlx)
 	glEnable(GL_BLEND);
 	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 	glUniform1i(glGetUniformLocation(context->shaderprogram, "OutTexture"), 0);
-	if (!mlx_parse_font_atlas(mlx))
-		return (false);
 	glfwSetWindowSizeCallback(mlx->window, &mlx_on_resize);
 	mlx_on_resize(mlx->window, mlx->width, mlx->height);
 	return (true);

--- a/src/utils/mlx_list_utils.c
+++ b/src/utils/mlx_list_utils.c
@@ -6,7 +6,7 @@
 /*   By: lde-la-h <lde-la-h@student.codam.nl>         +#+                     */
 /*                                                   +#+                      */
 /*   Created: 2022/01/31 15:20:51 by lde-la-h      #+#    #+#                 */
-/*   Updated: 2022/02/17 11:52:25 by lde-la-h      ########   odam.nl         */
+/*   Updated: 2022/02/28 17:48:53 by lde-la-h      ########   odam.nl         */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -48,26 +48,18 @@ void	mlx_lstadd_front(t_mlx_list **lst, t_mlx_list *new)
 t_mlx_list	*mlx_lstremove(t_mlx_list **lst, void *value, \
 bool (*comp)(void *, void*))
 {
-	t_mlx_list		*temp;
-	t_mlx_list		*prev;
+	t_mlx_list	*lstcpy;
 
-	temp = *lst;
-	if (temp != NULL && comp(temp->content, value))
-	{
-		*lst = temp->next;
-		temp->prev = NULL;
-		temp->next = NULL;
-		return (temp);
-	}
-	while (temp && !comp(temp->content, value))
-	{
-		prev = temp->prev;
-		temp = temp->next;
-	}
-	if (!temp)
+	lstcpy = *lst;
+	while (lstcpy && !comp(lstcpy->content, value))
+		lstcpy = lstcpy->next;
+	if (lstcpy == NULL)
 		return (NULL);
-	prev->next = temp->next;
-	temp->next = NULL;
-	temp->prev = NULL;
-	return (temp);
+	if (lstcpy == *lst)
+		*lst = lstcpy->next;
+	if (lstcpy->next != NULL)
+		lstcpy->next->prev = lstcpy->prev;
+	if (lstcpy->prev != NULL)
+		lstcpy->prev->next = lstcpy->next;
+	return (lstcpy);
 }


### PR DESCRIPTION
# Improvements
- Instead of 1 image per character, its 1 image per string
- Reduced draw calls, before limit was 20-30 strings on a window, now its up to 200-2000 depending on the machine with little lag
- Also corrects some behaviour such image deletion.

## Example, still same output, better peformance.
![image](https://user-images.githubusercontent.com/63303990/156036179-7350ddee-e918-4687-8eea-56aa389f5631.png)

## 1500 Images on the window

This is a bit of an extreme scenario also with smaller images you can have more on the window.
At this point there is noticeable lag but still sort of useable.

![image](https://user-images.githubusercontent.com/63303990/156035990-0a818152-39aa-4957-aae3-bca6bfefc03b.png)

## Bloopers

Funny accident 🤡 

<img width="793" alt="Screen Shot 2022-02-28 at 7 18 56 PM" src="https://user-images.githubusercontent.com/63303990/156036633-6bd97a53-bba9-4c63-be59-f51d222b0256.png">
