### PR TITLE
Add generic homebrew path finding option to work with custom homebrew…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@
 #                                                         ::::::::             #
 #    Makefile                                           :+:    :+:             #
 #                                                      +:+                     #
-#    By: W2Wizard <w2.wizzard@gmail.com>              +#+                      #
+#    By: vvissche <vvissche@student.codam.nl>         +#+                      #
 #                                                    +#+                       #
 #    Created: 2022/02/26 21:32:49 by W2Wizard      #+#    #+#                  #
-#    Updated: 2022/03/10 12:27:54 by lde-la-h      ########   odam.nl          #
+#    Updated: 2022/03/13 16:58:14 by vvissche      ########   odam.nl          #
 #                                                                              #
 # **************************************************************************** #
 
@@ -38,6 +38,15 @@ else
 
 		# Default
 		DYLIB_EXISTS = test -e /usr/local/lib/libglfw.3.dylib || echo "false"
+
+		# Generic Homebrew path
+		ifneq ($(DYLIB_EXISTS), false)
+			BREW_GLFW_PREFIX := $(shell brew --prefix glfw)
+			DYLIB_EXISTS = test -e $(BREW_GLFW_PREFIX)"/lib/libglfw.3.dylib" || echo "false"
+			ifneq ($($DYLIB_EXISTS), false)
+				HEADERS += -I $(BREW_GLFW_PREFIX)"/include"
+			endif
+		endif
 
 		# Homebrew path
 		ifneq ($(DYLIB_EXISTS), false)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 #                                                         ::::::::             #
 #    Makefile                                           :+:    :+:             #
 #                                                      +:+                     #
-#    By: vvissche <vvissche@student.codam.nl>         +#+                      #
+#    By: W2Wizard <w2.wizzard@gmail.com>              +#+                      #
 #                                                    +#+                       #
 #    Created: 2022/02/26 21:32:49 by W2Wizard      #+#    #+#                  #
 #    Updated: 2022/03/13 16:58:14 by vvissche      ########   odam.nl          #
@@ -42,25 +42,9 @@ else
 		# Generic Homebrew path
 		ifneq ($(DYLIB_EXISTS), false)
 			BREW_GLFW_PREFIX := $(shell brew --prefix glfw)
-			DYLIB_EXISTS = test -e $(BREW_GLFW_PREFIX)"/lib/libglfw.3.dylib" || echo "false"
+			DYLIB_EXISTS = test -e $(BREW_GLFW_PREFIX)/lib/libglfw.3.dylib || echo "false"
 			ifneq ($($DYLIB_EXISTS), false)
-				HEADERS += -I $(BREW_GLFW_PREFIX)"/include"
-			endif
-		endif
-
-		# Homebrew path
-		ifneq ($(DYLIB_EXISTS), false)
-			DYLIB_EXISTS = test -e /opt/homebrew/Cellar/glfw/3.3.6/lib/libglfw.3.dylib || echo "false"
-			ifneq ($(DYLIB_EXISTS), false)
-				HEADERS += -I /opt/homebrew/Cellar/glfw/3.3.6/include
-			endif
-		endif
-		
-		# Homebrew42 path
-		ifneq ($(DYLIB_EXISTS), false)
-			DYLIB_EXISTS = test -e /Users/$(USER)/.brew/opt/glfw/lib/libglfw.3.dylib || echo "false"
-			ifneq ($(DYLIB_EXISTS), false)
-				HEADERS += -I /Users/$(USER)/.brew/opt/glfw/include
+				HEADERS += -I $(BREW_GLFW_PREFIX)/include
 			endif
 		endif
         include Makefile_Unix.mk


### PR DESCRIPTION
… setups and rely less on hardcoded variants

Should work for most homebrew setups.
Tested on a generic homebrew install on macos and a custom install on a Codam iMac (not tested with homebrew42 setup)
So this could, in theory, make the other two blocks obsolete, but I couldn't test with homebrew42, so that should be checked before.

Signed-off-by: Vincent@Codam <>