### PR TITLE
Fix endian dependent color reading

### DIFF
--- a/src/textures/mlx_xpm42.c
+++ b/src/textures/mlx_xpm42.c
@@ -37,15 +37,18 @@
  * straight forward to this format however.
  */
 
+//= Private =//
+
 /**
  * Parses HEX color channel e.g: "0F"
  * 
  * @param channel The 2 character string to parse.
  * @return Int value of the channel.
  */
-static uint8_t parse_hex_channel(char *channel) {
+static uint8_t mlx_parse_hex_channel(char *channel) 
+{
 	char temp_chan[] = {channel[0], channel[1], '\0'};
-	return (uint8_t)strtol(temp_chan, NULL, 16);
+	return (strtol(temp_chan, NULL, 16));
 }
 
 /**

--- a/src/textures/mlx_xpm42.c
+++ b/src/textures/mlx_xpm42.c
@@ -38,6 +38,17 @@
  */
 
 /**
+ * Parses HEX color channel e.g: "0F"
+ * 
+ * @param channel The 2 character string to parse.
+ * @return Int value of the channel.
+ */
+static uint8_t parse_hex_channel(char *channel) {
+	char temp_chan[] = {channel[0], channel[1], '\0'};
+	return (uint8_t)strtol(temp_chan, NULL, 16);
+}
+
+/**
  * Parses the XPM coolor value entry e.g: ".X #00FF00FF"
  * into the color table while also verifying the format.
  * 
@@ -57,8 +68,14 @@ static bool mlx_insert_xpm_entry(xpm_t* xpm, char* line, uint32_t* ctable, size_
 	if (!isspace(line[xpm->cpp]) || line[xpm->cpp + 1] != '#' || !isalnum(line[xpm->cpp + 2]))
 		return (false);
 
+	uint32_t color = 0;
+	size_t start_offset = xpm->cpp + 2;
+	color |= parse_hex_channel(line + start_offset) << 24;
+	color |= parse_hex_channel(line + start_offset + 2) << 16;
+	color |= parse_hex_channel(line + start_offset + 4) << 8;
+	color |= parse_hex_channel(line + start_offset + 6);
+	
 	int32_t index = mlx_fnv_hash(line, xpm->cpp) % s;
-	uint32_t color = (uint32_t)strtol(line + xpm->cpp + 2, NULL, 16);
 	ctable[index] = xpm->mode == 'm' ? mlx_rgba_to_mono(color) : color;
 	return (true);
 }

--- a/src/textures/mlx_xpm42.c
+++ b/src/textures/mlx_xpm42.c
@@ -45,7 +45,7 @@
  * @param channel The 2 character string to parse.
  * @return Int value of the channel.
  */
-static uint8_t mlx_parse_hex_channel(char *channel) 
+static uint8_t mlx_parse_hex_channel(char* channel) 
 {
 	char temp_chan[] = {channel[0], channel[1], '\0'};
 	return (strtol(temp_chan, NULL, 16));

--- a/src/textures/mlx_xpm42.c
+++ b/src/textures/mlx_xpm42.c
@@ -73,10 +73,10 @@ static bool mlx_insert_xpm_entry(xpm_t* xpm, char* line, uint32_t* ctable, size_
 
 	uint32_t color = 0;
 	size_t start_offset = xpm->cpp + 2;
-	color |= parse_hex_channel(line + start_offset) << 24;
-	color |= parse_hex_channel(line + start_offset + 2) << 16;
-	color |= parse_hex_channel(line + start_offset + 4) << 8;
-	color |= parse_hex_channel(line + start_offset + 6);
+	color |= mlx_parse_hex_channel(line + start_offset) << 24;
+	color |= mlx_parse_hex_channel(line + start_offset + 2) << 16;
+	color |= mlx_parse_hex_channel(line + start_offset + 4) << 8;
+	color |= mlx_parse_hex_channel(line + start_offset + 6);
 	
 	int32_t index = mlx_fnv_hash(line, xpm->cpp) % s;
 	ctable[index] = xpm->mode == 'm' ? mlx_rgba_to_mono(color) : color;

--- a/src/textures/mlx_xpm42.c
+++ b/src/textures/mlx_xpm42.c
@@ -52,7 +52,7 @@ static uint8_t mlx_parse_hex_channel(char *channel)
 }
 
 /**
- * Parses the XPM coolor value entry e.g: ".X #00FF00FF"
+ * Parses the XPM color value entry e.g: ".X #00FF00FF"
  * into the color table while also verifying the format.
  * 
  * @param xpm The XPM.


### PR DESCRIPTION
## Issue

When reading the HEX colors from a xpm42 file `strtol` is used over the whole HEX sequence, `strtol` treats this whole sequence as one number. Therefor when the endian doesn't match the presumed RGBA order the result is not the expected color.

Sample image with incorrect endian:
![incorect](https://user-images.githubusercontent.com/28459732/160482459-a4b3bcaf-a28b-42fa-9cfc-e3895be159a4.png)

## Solution

Instead of using `strtol` over the whole HEX sequence, use it only over the individual color channels and then manually bit shift the channels to the expected location. 

Sample image with HEX channel correction:
![corect](https://user-images.githubusercontent.com/28459732/160482241-2b3c9f93-1cf0-4286-9ac4-2c1bbefd9455.png)
